### PR TITLE
Ajustando passagem da variável endereço

### DIFF
--- a/mapa.js
+++ b/mapa.js
@@ -56,7 +56,6 @@ $(document).ready(function () {
 
         alert(endereco);
 
-        carregarNoMapa($(endereco).val()); // Esse parte. De passar como parametro.
+        carregarNoMapa(endereco); // Esse parte. De passar como parametro.
     })
-
 });


### PR DESCRIPTION
Na verdade o que deve ser passado é a variável endereço recém construída.

O código: `$(endereco).val()` tentará pegar o valor de um campo que não existe. Ex.: `$('Avenida Antonio de Almeida Filho - 3801, Praia de Itaparica, Vila Velha').val()`.
